### PR TITLE
Add possible to send packets with no IP header if allowed any IP on the device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 wireguard-go
 vendor
 .gopath
+.idea/
 ireallywantobuildon_linux.go

--- a/device/allowedips_test.go
+++ b/device/allowedips_test.go
@@ -20,26 +20,6 @@ type testPairCommonBits struct {
 	match uint
 }
 
-type testPairTrieInsert struct {
-	key  []byte
-	cidr uint
-	peer *Peer
-}
-
-type testPairTrieLookup struct {
-	key  []byte
-	peer *Peer
-}
-
-func printTrie(t *testing.T, p *trieEntry) {
-	if p == nil {
-		return
-	}
-	t.Log(p)
-	printTrie(t, p.child[0])
-	printTrie(t, p.child[1])
-}
-
 func TestCommonBits(t *testing.T) {
 
 	tests := []testPairCommonBits{

--- a/device/receive.go
+++ b/device/receive.go
@@ -624,10 +624,6 @@ func (peer *Peer) RoutineSequentialReceiver() {
 				)
 				continue
 			}
-
-		default:
-			logInfo.Println("Packet with invalid IP version from", peer)
-			continue
 		}
 
 		// write to tun device

--- a/device/send.go
+++ b/device/send.go
@@ -301,10 +301,15 @@ func (device *Device) RoutineReadFromTUN() {
 			peer = device.allowedips.LookupIPv6(dst)
 
 		default:
+			peer = device.allowedips.Any()
+			if peer != nil {
+				break
+			}
 			logDebug.Println("Received packet with unknown IP version")
 		}
 
 		if peer == nil {
+			logDebug.Print("Peer not found")
 			continue
 		}
 


### PR DESCRIPTION
## Usecase

1. Create a WG device `wg-0`
1. Set to `wg-0` property to allow any IP.
2. Send packet to `wg-0` with no IP header.


**Actual**: the device will do nothing. In logs will log the text `"Received packet with unknown IP version"`.
**Expected**: the device will send a packet if the device allows any IP.


