### PR TITLE
tun: return a better error message if /dev/net/tun doesn't exist

### DIFF
--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -380,6 +380,9 @@ func (tun *NativeTun) Close() error {
 func CreateTUN(name string, mtu int) (Device, error) {
 	nfd, err := unix.Open(cloneDevicePath, os.O_RDWR, 0)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("CreateTUN(%q) failed; tuntap %s does not exist", name, cloneDevicePath)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
It was just returning "no such file or directory" (the String of the
syscall.Errno returned by CreateTUN).

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>