### PR TITLE
device: return generic error from Ipc{Get,Set}Operation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.zx2c4.com/wireguard
 
-go 1.12
+go 1.13
 
 require (
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc


### PR DESCRIPTION
This makes uapi.go's public API conform to Go style in terms
of error types.

Signed-off-by: David Anderson <danderson@tailscale.com>