### PR TITLE
device: move stats fields back down and add test diagnostics

### DIFF
--- a/device/peer.go
+++ b/device/peer.go
@@ -22,6 +22,14 @@ const (
 )
 
 type Peer struct {
+	// Mostly protects endpoint, but is generally taken whenever we modify peer
+	sync.RWMutex
+	keypairs                    Keypairs
+	handshake                   Handshake
+	device                      *Device
+	endpoint                    conn.Endpoint
+	persistentKeepaliveInterval uint16
+
 	// These fields are accessed with atomic operations, which must be
 	// 64-bit aligned even on 32-bit platforms. Go guarantees that an
 	// allocated struct will be 64-bit aligned. So we place
@@ -35,14 +43,6 @@ type Peer struct {
 	// This field is only 32 bits wide, but is still aligned to 64
 	// bits. Don't place other atomic fields after this one.
 	isRunning AtomicBool
-
-	// Mostly protects endpoint, but is generally taken whenever we modify peer
-	sync.RWMutex
-	keypairs                    Keypairs
-	handshake                   Handshake
-	device                      *Device
-	endpoint                    conn.Endpoint
-	persistentKeepaliveInterval uint16
 
 	timers struct {
 		retransmitHandshake     *Timer

--- a/device/peer_test.go
+++ b/device/peer_test.go
@@ -6,6 +6,7 @@
 package device
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
 )
@@ -24,6 +25,19 @@ func checkAlignment(t *testing.T, name string, offset uintptr) {
 // hard segfault at runtime.
 func TestPeerAlignment(t *testing.T) {
 	var p Peer
+
+	typ := reflect.TypeOf(p)
+	t.Logf("Peer type size: %d, with fields:", typ.Size())
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		t.Logf("\t%30s\toffset=%3v\t(type size=%3d, align=%d)",
+			field.Name,
+			field.Offset,
+			field.Type.Size(),
+			field.Type.Align(),
+		)
+	}
+
 	checkAlignment(t, "Peer.stats", unsafe.Offsetof(p.stats))
 	checkAlignment(t, "Peer.isRunning", unsafe.Offsetof(p.isRunning))
 }


### PR DESCRIPTION
This reverts the movement of fields from d49f4e9.
That commit was cherry-picked from another branch where a field
had changed and misaligned the atomic fields. After cherry-picking,
moving the fields was no longer necessary but got dragged along.

Signed-off-by: David Crawshaw <crawshaw@tailscale.com>