### PR TITLE
wgcfg: rename Key to PublicKey

### DIFF
--- a/wgcfg/config.go
+++ b/wgcfg/config.go
@@ -23,7 +23,7 @@ type Config struct {
 }
 
 type Peer struct {
-	PublicKey           Key
+	PublicKey           PublicKey
 	PresharedKey        SymmetricKey
 	AllowedIPs          []CIDR
 	Endpoints           []Endpoint

--- a/wgcfg/key_test.go
+++ b/wgcfg/key_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 func TestKeyBasics(t *testing.T) {
-	k1, err := NewPresharedKey()
+	pk1, err := NewPrivateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
+	k1 := pk1.Public()
 
 	b, err := k1.MarshalJSON()
 	if err != nil {
@@ -18,7 +19,7 @@ func TestKeyBasics(t *testing.T) {
 
 	t.Run("JSON round-trip", func(t *testing.T) {
 		// should preserve the keys
-		k2 := new(Key)
+		k2 := new(PublicKey)
 		if err := k2.UnmarshalJSON(b); err != nil {
 			t.Fatal(err)
 		}
@@ -39,10 +40,11 @@ func TestKeyBasics(t *testing.T) {
 
 	t.Run("second key", func(t *testing.T) {
 		// A second call to NewPresharedKey should make a new key.
-		k3, err := NewPresharedKey()
+		pk3, err := NewPrivateKey()
 		if err != nil {
 			t.Fatal(err)
 		}
+		k3 := pk3.Public()
 		if bytes.Equal(k1[:], k3[:]) {
 			t.Fatalf("k1 %v == k3 %v", k1[:], k3[:])
 		}
@@ -52,6 +54,7 @@ func TestKeyBasics(t *testing.T) {
 		}
 	})
 }
+
 func TestPrivateKeyBasics(t *testing.T) {
 	pri, err := NewPrivateKey()
 	if err != nil {
@@ -81,7 +84,7 @@ func TestPrivateKeyBasics(t *testing.T) {
 	})
 
 	t.Run("JSON incompatible with Key", func(t *testing.T) {
-		k2 := new(Key)
+		k2 := new(PublicKey)
 		if err := k2.UnmarshalJSON(b); err == nil {
 			t.Fatalf("successfully decoded private key as key")
 		}

--- a/wgcfg/parser.go
+++ b/wgcfg/parser.go
@@ -100,7 +100,7 @@ func parsePersistentKeepalive(s string) (uint16, error) {
 	return uint16(m), nil
 }
 
-func parseKeyHex(s string) (*Key, error) {
+func parseKeyHex(s string) (*PublicKey, error) {
 	k, err := hex.DecodeString(s)
 	if err != nil {
 		return nil, &ParseError{"Invalid key: " + err.Error(), s}
@@ -108,7 +108,7 @@ func parseKeyHex(s string) (*Key, error) {
 	if len(k) != KeySize {
 		return nil, &ParseError{"Keys must decode to exactly 32 bytes", s}
 	}
-	var key Key
+	var key PublicKey
 	copy(key[:], k)
 	return &key, nil
 }


### PR DESCRIPTION
A few minor review cleanups while here (e.g. remove unused LessThan).

First of several cleanups for wgcfg based on Jason's comments.