### PR TITLE
Add nil check before convert typed error back

### DIFF
--- a/device/uapi.go
+++ b/device/uapi.go
@@ -423,7 +423,7 @@ func (device *Device) IpcHandle(socket net.Conn) {
 	switch op {
 	case "set=1\n":
 		err = device.IpcSetOperation(buffered.Reader)
-		if !errors.As(err, &status) {
+		if err != nil && !errors.As(err, &status) {
 			// should never happen
 			device.log.Error.Println("Invalid UAPI error:", err)
 			status = &IPCError{1}
@@ -431,7 +431,7 @@ func (device *Device) IpcHandle(socket net.Conn) {
 
 	case "get=1\n":
 		err = device.IpcGetOperation(buffered.Writer)
-		if !errors.As(err, &status) {
+		if err != nil && !errors.As(err, &status) {
 			// should never happen
 			device.log.Error.Println("Invalid UAPI error:", err)
 			status = &IPCError{1}


### PR DESCRIPTION
Since `errors.As(err, target)` returns `false` when `err` is `nil`,
which cause `status` set to `1` when no error occurs for `IpcGetOperation` and `IpcSetOperation`.

Should be able to fix #17

Signed-off-by: Wenxuan Zhao <viz@linux.com>