### PR TITLE
device/noise-helpers.go: replace deprecated curve25519.ScalarMult

### DIFF
--- a/device/noise-helpers.go
+++ b/device/noise-helpers.go
@@ -97,6 +97,10 @@ func (sk *NoisePrivateKey) publicKey() (pk NoisePublicKey) {
 func (sk *NoisePrivateKey) sharedSecret(pk NoisePublicKey) (ss [NoisePublicKeySize]byte) {
 	apk := (*[NoisePublicKeySize]byte)(&pk)
 	ask := (*[NoisePrivateKeySize]byte)(sk)
-	curve25519.ScalarMult(&ss, ask, apk)
+	p, err := curve25519.X25519(ask[:], apk[:])
+	if err != nil {
+		panic(err)
+	}
+	copy(ss[:], p)
 	return ss
 }


### PR DESCRIPTION
replace [deprecated](https://go-review.googlesource.com/c/crypto/+/205157/) `curve25519.ScalarMult` with `curve25519.X25519`,
which will throw an error when a bad ip is used.

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>