### PR TITLE
Replace direct syscalls on macOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.13
 require (
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
 	golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5
-	golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a
+	golang.org/x/sys v0.0.0-20201027130517-9d1ec526b7bf
 	golang.org/x/text v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a h1:e3IU37lwO4aq3uoRKINC7JikojFmE5gO7xhfxs8VC34=
-golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201027130517-9d1ec526b7bf h1:HmHgHRpqpvB74D7bjXkue6kkHJfOrKyYJtW6Sv4jpI4=
+golang.org/x/sys v0.0.0-20201027130517-9d1ec526b7bf/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
This PR replaces all uses of direct syscalls (i.e. `unix.Syscall(unix.SYS_*, ...)`) on macOS by the respective functionality from the `golang.org/x/sys/unix` package using macOS libSystem. The support for direct syscalls on macOS is discouraged and was recently removed from `golang.org/x/sys/unix`, see https://golang.org/cl/250437 (golang/sys@6fcdbc0bbc04dcd9e7dc145879ceaf9bf1c6ff03). This broke the build of `wireguard-go` against the latest `golang.org/x/sys/unix` version, as reported in golang/go#41868.

See individual commit messages for more details.

Tested on macOS 10.15 against a wireguard server running on Ubuntu Linux 20.04.

/cc @bradfitz