### PR TITLE
allowedips: Fix removeByPeer 

### DIFF
--- a/device/allowedips.go
+++ b/device/allowedips.go
@@ -100,7 +100,10 @@ func (node *trieEntry) removeByPeer(p *Peer) *trieEntry {
 	if node.child[0] == nil {
 		return node.child[1]
 	}
-	return node.child[0]
+	if node.child[1] == nil {
+		return node.child[0]
+	}
+	return node
 }
 
 func (node *trieEntry) choose(ip net.IP) byte {


### PR DESCRIPTION
I have found what I believe to be a mistake in the implementation of removeByPeer.

Currently, it returns node.child[0] without checking if node.child[1] is nil, causing the loss of the right child if it was not nil. I have added a check to check if node.child[1] is nil before returning node.child[0]; otherwise, we return node.

The [kernel implementation](https://github.com/WireGuard/wireguard-linux-compat/blob/master/src/allowedips.c#L112-L117) does not have this problem as it correctly checks for this scenario.

Signed-off-by: Damian Ho <damian_ho_xu_yang@yahoo.com>