### PR TITLE
Fix double free in RoutineReceiveIncoming

### DIFF
--- a/device/receive.go
+++ b/device/receive.go
@@ -104,6 +104,7 @@ func (device *Device) RoutineReceiveIncoming(recv conn.ReceiveFunc) {
 			if deathSpiral < 10 {
 				deathSpiral++
 				time.Sleep(time.Second / 3)
+				buffer = device.GetMessageBuffer()
 				continue
 			}
 			return


### PR DESCRIPTION
Note: this bug is "hidden" by avoiding "death spiral" code path by
commit: 6228659a

If the code reached "death spiral" mechanism, there would be multiple
double frees happening. This results in a deadlock on IOS, because the
pools are fixed size and goroutine might stop until somebody makes
space in the pool.

This was almost 100% repro on the new Arm macbooks:
- Build with 'ios' tag for Mac. This will enable bounded pools.
- Somehow call device.IpcSet at least couple of times (update config)
- device.BindUpdate() would be triggered
- RoutineReceiveIncoming would enter "death spiral".
- RoutineReceiveIncoming would stall on double free (pool is already
full)
- The stuck routine would deadlock 'device.closeBindLocked()' function
on line 'netc.stopping.Wait()'

Signed-off-by: Kristupas Antanavičius <kristupas.antanavicius@nordsec.com>