### PR TITLE
Two Handhake initiation releated race-conditions fixed

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -193,7 +193,10 @@ func (peer *Peer) keepKeyFreshSending() {
 	}
 	nonce := atomic.LoadUint64(&keypair.sendNonce)
 	if nonce > RekeyAfterMessages || (keypair.isInitiator && time.Since(keypair.created) > RekeyAfterTime) {
-		peer.SendHandshakeInitiation(false)
+		// Do not send new HandshakeInitiation, if handshake retry is already in progress
+		if !peer.handshakeInProgress() {
+			peer.SendHandshakeInitiation(false)
+		}
 	}
 }
 
@@ -298,7 +301,10 @@ top:
 
 	keypair := peer.keypairs.Current()
 	if keypair == nil || atomic.LoadUint64(&keypair.sendNonce) >= RejectAfterMessages || time.Since(keypair.created) >= RejectAfterTime {
-		peer.SendHandshakeInitiation(false)
+		// Do not send new HandshakeInitiation, if handshake retry is already in progress
+		if !peer.handshakeInProgress() {
+			peer.SendHandshakeInitiation(false)
+		}
 		return
 	}
 

--- a/device/send.go
+++ b/device/send.go
@@ -89,7 +89,7 @@ func (peer *Peer) SendKeepalive() {
 
 func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 	if !isRetry {
-		atomic.StoreUint32(&peer.timers.handshakeAttempts, 0)
+		atomic.StoreUint32(&peer.timers.handshakeAttempts, 1)
 	}
 
 	peer.handshake.mutex.RLock()


### PR DESCRIPTION
* Fix race-condition between data TX watchdog timer and handshakes retries timer
* (at the same time) Fix and unify handshake attempts counter usage: now 0 means no HI in progress. Can use that timer to check if and HIs already sent.
* Do not flood new handhake initiations, if HI is already scheduled by somebody else.