### PR TITLE
Fix a bug found on the centos7.5.1804 platform

### DIFF
--- a/device/uapi.go
+++ b/device/uapi.go
@@ -453,9 +453,9 @@ func (device *Device) IpcHandle(socket net.Conn) {
 		}
 		if status != nil {
 			device.log.Errorf("%v", status)
-			fmt.Fprintf(buffered, "errno=%d\n\n", status.ErrorCode())
+			fmt.Fprintf(buffered, "errno=%d\n\nEnd\n", status.ErrorCode())
 		} else {
-			fmt.Fprintf(buffered, "errno=0\n\n")
+			fmt.Fprintf(buffered, "errno=0\n\nEnd\n")
 		}
 		buffered.Flush()
 	}


### PR DESCRIPTION
If the response message is exactly same to the fscanf()'s second parameter, the fscanf() in the userspace_set_device() cannot get the response and cannot return. This fix has been verified using my environment(CentOS Linux release 7.5.1804 (Core)).