### PR TITLE
tun/netstack: ensure `(*netTun).incomingPacket` chan is closed

### DIFF
--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -164,6 +164,10 @@ func (tun *netTun) Close() error {
 
 	tun.ep.Close()
 
+	if tun.incomingPacket != nil {
+		close(tun.incomingPacket)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Without this, `device.Close()` will deadlock.