### PR TITLE
device: optimize Peer.String even more so

### DIFF
--- a/device/peer.go
+++ b/device/peer.go
@@ -139,20 +139,30 @@ func (peer *Peer) String() string {
 	//
 	// except that it is considerably more efficient.
 	src := peer.handshake.remoteStatic
-	b64 := func(input byte) byte {
-		return input + 'A' + byte(((25-int(input))>>8)&6) - byte(((51-int(input))>>8)&75) - byte(((61-int(input))>>8)&15) + byte(((62-int(input))>>8)&3)
-	}
 	b := []byte("peer(____…____)")
+
 	const first = len("peer(")
 	const second = len("peer(____…")
-	b[first+0] = b64((src[0] >> 2) & 63)
-	b[first+1] = b64(((src[0] << 4) | (src[1] >> 4)) & 63)
-	b[first+2] = b64(((src[1] << 2) | (src[2] >> 6)) & 63)
-	b[first+3] = b64(src[2] & 63)
-	b[second+0] = b64(src[29] & 63)
-	b[second+1] = b64((src[30] >> 2) & 63)
-	b[second+2] = b64(((src[30] << 4) | (src[31] >> 4)) & 63)
-	b[second+3] = b64((src[31] << 2) & 63)
+	const encodeStd = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+	// Convert 3x 8bit source bytes into 4 bytes
+	val := uint(src[0+0])<<16 | uint(src[0+1])<<8 | uint(src[0+2])
+
+	b[first+0] = encodeStd[val>>18&0x3F]
+	b[first+1] = encodeStd[val>>12&0x3F]
+	b[first+2] = encodeStd[val>>6&0x3F]
+	b[first+3] = encodeStd[val&0x3F]
+
+	val = /*uint(src[27+0])<<16 | uint(src[27+1])<<8 |*/ uint(src[27+2])
+
+	b[second+0] = encodeStd[val&0x3F]
+
+	val = uint(src[30+0])<<16 | uint(src[30+1])<<8 /*| uint(src[30+2])*/
+
+	b[second+1] = encodeStd[val>>18&0x3F]
+	b[second+2] = encodeStd[val>>12&0x3F]
+	b[second+3] = encodeStd[val>>6&0x3F]
+
 	return string(b)
 }
 

--- a/device/peer_test.go
+++ b/device/peer_test.go
@@ -1,0 +1,20 @@
+package device
+
+import (
+	"testing"
+)
+
+var sinkS string
+
+func BenchmarkPeerString(b *testing.B) {
+	k := [32]byte{0: 0x4e, 1: 0xb3, 2: 0x2f, 29: 0x16, 30: 0x5d, 31: 0x7d} // TrMv…WXX0
+	p := &Peer{handshake: Handshake{remoteStatic: k}}
+	s := p.String()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		s = p.String()
+	}
+	sinkS = s
+}


### PR DESCRIPTION
```
name          old time/op    new time/op    delta
PeerString-8    49.5ns ±17%    32.6ns ±17%  -34.09%  (p=0.000 n=10+10)

name          old alloc/op   new alloc/op   delta
PeerString-8     24.0B ± 0%     24.0B ± 0%     ~     (all equal)

name          old allocs/op  new allocs/op  delta
PeerString-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```

Signed-off-by: Alexander Yastrebov <yastrebov.alex@gmail.com>