### PR TITLE
device: Allow buffer memory growth to be limited at run time

### DIFF
--- a/device/queueconstants_default.go
+++ b/device/queueconstants_default.go
@@ -13,5 +13,8 @@ const (
 	QueueInboundSize           = 1024
 	QueueHandshakeSize         = 1024
 	MaxSegmentSize             = (1 << 16) - 1 // largest possible UDP datagram
-	PreallocatedBuffersPerPool = 0             // Disable and allow for infinite memory growth
 )
+
+// Infinite memory growth quickly oom-kills processes on small devices
+// Allow fine tuning on such systems.
+var PreallocatedBuffersPerPool uint32 = 0          // Disable and allow for infinite memory growth


### PR DESCRIPTION
The infinite memory growth allowed by the default PreallocatedBuffersPerPool setting causes processes to be oom-killed on low memory devices. This occurs even when a soft limit is set with GOMEMLIMIT. Specifically running tailscale on a linux device (openwrt, mips, 128MB RAM) will exhaust all memory and be oom-killed when put under heavy load. Allowing this value to be overwritten as is done in the iOS build will allow tuning to cap memory expansion and prevent oom-kill.

see tailscale issue thread for further info:
  https://github.com/tailscale/tailscale/issues/7272