### PR TITLE
conn: fix StdNetBind fallback on Windows

### DIFF
--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -229,7 +229,7 @@ func (s *StdNetBind) makeReceiveIPv4(pc *ipv4.PacketConn, conn *net.UDPConn) Rec
 			sizes[i] = msg.N
 			addrPort := msg.Addr.(*net.UDPAddr).AddrPort()
 			ep := asEndpoint(addrPort)
-			getSrcFromControl(msg.OOB, ep)
+			getSrcFromControl(msg.OOB[:msg.NN], ep)
 			eps[i] = ep
 		}
 		return numMsgs, nil
@@ -262,7 +262,7 @@ func (s *StdNetBind) makeReceiveIPv6(pc *ipv6.PacketConn, conn *net.UDPConn) Rec
 			sizes[i] = msg.N
 			addrPort := msg.Addr.(*net.UDPAddr).AddrPort()
 			ep := asEndpoint(addrPort)
-			getSrcFromControl(msg.OOB, ep)
+			getSrcFromControl(msg.OOB[:msg.NN], ep)
 			eps[i] = ep
 		}
 		return numMsgs, nil

--- a/conn/bind_std_test.go
+++ b/conn/bind_std_test.go
@@ -1,0 +1,22 @@
+package conn
+
+import "testing"
+
+func TestStdNetBindReceiveFuncAfterClose(t *testing.T) {
+	bind := NewStdNetBind().(*StdNetBind)
+	fns, _, err := bind.Open(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bind.Close()
+	buffs := make([][]byte, 1)
+	buffs[0] = make([]byte, 1)
+	sizes := make([]int, 1)
+	eps := make([]Endpoint, 1)
+	for _, fn := range fns {
+		// The ReceiveFuncs must not access conn-related fields on StdNetBind
+		// unguarded. Close() nils the conn-related fields resulting in a panic
+		// if they violate the mutex.
+		fn(buffs, sizes, eps)
+	}
+}


### PR DESCRIPTION
This is meant to address https://github.com/WireGuard/wireguard-go/pull/64#issuecomment-1454754220

> Should we remove the Windows code because it's not used? Or keep it because it could be used if for some reason you use bind_std on Windows instead of the winrio stuff? Or maybe the Windows code should use the control functions too?

Keep it for fallback, which was broken, and this commit addresses. The Windows code could eventually use the control functions. I don't know how SO_{RCV/SND}BUF sizing relates to a socket under the control of RIO and its ring. Something we will get deeper into with Windows work.

If RIO is unavailable, NewWinRingBind() falls back to StdNetBind. StdNetBind uses x/net/ipv{4,6}.PacketConn for sending and receiving datagrams, specifically via the {Read,Write}Batch methods. These methods are unimplemented on Windows and will return runtime errors as a result. This commit updates StdNetBind to fall back to the standard library net package for Windows.