### PR TITLE
conn,device: extract local endpoint into a field on peer

### DIFF
--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -81,11 +81,10 @@ func NewStdNetBind() Bind {
 type StdNetEndpoint struct {
 	// AddrPort is the endpoint destination.
 	netip.AddrPort
-	// src is the current sticky source address and interface index, if supported.
-	src struct {
-		netip.Addr
-		ifidx int32
-	}
+	// src is the current sticky source address and interface index, if
+	// supported. Typically this is a PKTINFO structure from/for control
+	// messages, see unix.PKTINFO for an example.
+	src []byte
 }
 
 var (
@@ -104,21 +103,17 @@ func (*StdNetBind) ParseEndpoint(s string) (Endpoint, error) {
 }
 
 func (e *StdNetEndpoint) ClearSrc() {
-	e.src.ifidx = 0
-	e.src.Addr = netip.Addr{}
+	if e.src != nil {
+		// Truncate src, no need to reallocate.
+		e.src = e.src[:0]
+	}
 }
 
 func (e *StdNetEndpoint) DstIP() netip.Addr {
 	return e.AddrPort.Addr()
 }
 
-func (e *StdNetEndpoint) SrcIP() netip.Addr {
-	return e.src.Addr
-}
-
-func (e *StdNetEndpoint) SrcIfidx() int32 {
-	return e.src.ifidx
-}
+// See sticky_default,linux, etc for implementaitons of SrcIP and SrcIfidx.
 
 func (e *StdNetEndpoint) DstToBytes() []byte {
 	b, _ := e.AddrPort.MarshalBinary()
@@ -127,10 +122,6 @@ func (e *StdNetEndpoint) DstToBytes() []byte {
 
 func (e *StdNetEndpoint) DstToString() string {
 	return e.AddrPort.String()
-}
-
-func (e *StdNetEndpoint) SrcToString() string {
-	return e.src.Addr.String()
 }
 
 func listenNet(network string, port int) (*net.UDPConn, int, error) {

--- a/conn/sticky_default.go
+++ b/conn/sticky_default.go
@@ -7,6 +7,20 @@
 
 package conn
 
+import "net/netip"
+
+func (e *StdNetEndpoint) SrcIP() netip.Addr {
+	return netip.Addr{}
+}
+
+func (e *StdNetEndpoint) SrcIfidx() int32 {
+	return 0
+}
+
+func (e *StdNetEndpoint) SrcToString() string {
+	return ""
+}
+
 // TODO: macOS, FreeBSD and other BSDs likely do support this feature set, but
 // use alternatively named flags and need ports and require testing.
 


### PR DESCRIPTION
Remove the need for synchronization around endpoints and allocation concerns by arranging for a concrete type that carries local endpoint information when used.

Along this path we could also remove the need for the interface/pointer type around Endpoint too, we would just need to teach bind_windows.go to translate between the types when necessary - but these structures are small.

There is also an opportunity opened here to improve the naming of the methods on Endpoint, as they are still based on the notion that there is both a Src and a Dst in the Endpoint. I am sending this for discussion prior to additional cleanup so we can discuss the core behavior / structure change first.