### PR TITLE
device: wait for and lock ipc operations during close

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -368,6 +368,8 @@ func (device *Device) RemoveAllPeers() {
 }
 
 func (device *Device) Close() {
+	device.ipcMutex.Lock()
+	defer device.ipcMutex.Unlock()
 	device.state.Lock()
 	defer device.state.Unlock()
 	if device.isClosed() {


### PR DESCRIPTION
If an IPC operation is in flight while close starts, it is possible for both processes to deadlock. Prevent this by taking the IPC lock at the start of close and for the duration.

Fixes tailscale/tailscale#8059