### PR TITLE
Fix crash on peer disconnect

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -376,12 +376,15 @@ func (device *Device) Close() {
 	device.state.state.Store(uint32(deviceStateClosed))
 	device.log.Verbosef("Device closing")
 
-	device.tun.device.Close()
 	device.downLocked()
 
 	// Remove peers before closing queues,
 	// because peers assume that queues are active.
 	device.RemoveAllPeers()
+
+	// call Close() here, so that app peer-related operations are finished
+	// before Close(), as it removes nic dispatcher used by peer receiver go-routine
+	device.tun.device.Close()
 
 	// We kept a reference to the encryption and decryption queues,
 	// in case we started any new peers that might write to them.


### PR DESCRIPTION
Hi

I've found a possible race condition resulting in a panic in wireguard-go.
It happens when a client session disconnects, not often - once in a
few days with a few (5-10) sessions running.
The app I'm working on is based on wireguard-go/tun/netstack/tun.go code.

The problem reveals itself as a panic (see below).
It happens when peer.RoutineSequentialReceiver() go-routine does a
(*tun.Device).Write(), which calls gvisor (*Endpoint).InjectInbound(),
but endpoint could have been made nil to this point of time, b/c
tun.stack.RemoveNIC(1) called from tunDev.Close() assigns nil to
endpoint.

A possible solution:
https://github.com/mysteriumnetwork/wireguard-go/pull/6/files

If I move
> device.tun.device.Close()

below the
> device.RemoveAllPeers()

thus making peer-related operations to finish before the
device.tun.device.Close(), then crash doesn't happen.

By now the code has been running for a week.
I'll test it for another week or two.


Trace:

> 2023-05-04T00:34:10.000 INF services\wireguard\service\service.go:162 > Cleaning up session 7f100e49-6517-4141-be66-1ac7c47ed5e8
> DEBUG: (myst) 2023/05/04 00:34:10 Device closing
> 2023-05-04T00:34:10.000 INF services\wireguard\service\stats_publisher.go:65 > Stopped publishing statistics for session 7f100e49-6517-4141-be66-1ac7c47ed5e8
> DEBUG: (myst) 2023/05/04 00:34:10 peer(/Zbg…wTzA) - Routine: sequential receiver - stopped
> panic: runtime error: invalid memory address or nil pointer dereference
> [signal 0xc0000005 code=0x0 addr=0x20 pc=0x7ff62082c781]

> goroutine 485845 [running]:
> [gvisor.dev/gvisor/pkg/tcpip/link/channel.(*Endpoint).InjectInbound(..](http://gvisor.dev/gvisor/pkg/tcpip/link/channel.(*Endpoint).InjectInbound(..).)
>         C:/Users/user/go/pkg/mod/[gvisor.dev/gvisor@v0.0.0-20221203005347-703fd9b7fbc0/pkg/tcpip/link/channel/channel.go:194](http://gvisor.dev/gvisor@v0.0.0-20221203005347-703fd9b7fbc0/pkg/tcpip/link/channel/channel.go:194)
> [github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack-provider.(*netTun).Write(0xc002211600](http://github.com/mysteriumnetwork/node/services/wireguard/endpoint/netstack-provider.(*netTun).Write(0xc002211600), {0xc0020348a0?, 0x1, 0xc0015ac810?}, 0x10)
>         C:/Users/user/src/node/services/wireguard/endpoint/netstack-provider/netstack.go:164 +0x141
> [golang.zx2c4.com/wireguard/device.(*Peer).RoutineSequentialReceiver(0xc001229c00](http://golang.zx2c4.com/wireguard/device.(*Peer).RoutineSequentialReceiver(0xc001229c00), 0x1)
>         C:/Users/user/go/pkg/mod/[golang.zx2c4.com/wireguard@v0.0.0-20230325221338-052af4a8072b/device/receive.go:513](http://golang.zx2c4.com/wireguard@v0.0.0-20230325221338-052af4a8072b/device/receive.go:513) +0x23a
> created by [golang.zx2c4.com/wireguard/device.(*Peer).Start](http://golang.zx2c4.com/wireguard/device.(*Peer).Start)
>         C:/Users/user/go/pkg/mod/[golang.zx2c4.com/wireguard@v0.0.0-20230325221338-052af4a8072b/device/peer.go:199](http://golang.zx2c4.com/wireguard@v0.0.0-20230325221338-052af4a8072b/device/peer.go:199) +0x2e5


A link to related code:

https://github.com/mysteriumnetwork/node/blob/5c109f64858da7c0c0add4e2dd7ce9e4e46c99e1/services/wireguard/endpoint/netstack-provider/netstack.go#L164