### PR TITLE
go.mod module name fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module golang.zx2c4.com/wireguard
+module golang.zx2c4.com/wireguard-go
 
 go 1.20
 


### PR DESCRIPTION
This PR fixes the go.mod name
This can be useful to install wireguard-go using `go install golang.zx2c4.com/wireguard-go@version`