### PR TITLE
tun/netstack goroutine leaks

### DIFF
--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -167,6 +167,7 @@ func (tun *netTun) WriteNotify() {
 
 func (tun *netTun) Close() error {
 	tun.stack.RemoveNIC(1)
+	tun.stack.Close()
 
 	if tun.events != nil {
 		close(tun.events)


### PR DESCRIPTION
**Issue**

`netstack` is not properly closed, causing goroutine leaks.

```
goroutine profile: total 123
108 @ 0x439d16 0xe27ea5 0xe27e8d 0xe27fb1 0xe44d70 0xe44d61 0x46cd21
#	0xe27ea4	gvisor.dev/gvisor/pkg/sync.Gopark+0x84					/go/src/.../vendor/gvisor.dev/gvisor/pkg/sync/runtime_unsafe.go:41
#	0xe27e8c	gvisor.dev/gvisor/pkg/sleep.(*Sleeper).nextWaker+0x6c			/go/src/.../vendor/gvisor.dev/gvisor/pkg/sleep/sleep_unsafe.go:209
#	0xe27fb0	gvisor.dev/gvisor/pkg/sleep.(*Sleeper).fetch+0x30			/go/src/.../vendor/gvisor.dev/gvisor/pkg/sleep/sleep_unsafe.go:256
#	0xe44d6f	gvisor.dev/gvisor/pkg/sleep.(*Sleeper).Fetch+0xaf			/go/src/.../vendor/gvisor.dev/gvisor/pkg/sleep/sleep_unsafe.go:279
#	0xe44d60	gvisor.dev/gvisor/pkg/tcpip/transport/tcp.(*processor).start+0xa0	/go/src/.../vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/dispatcher.go:287
```

**Fix**

Close `netstack` in `netTun.Close()`