### PR TITLE
go.mod: bump dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module golang.zx2c4.com/wireguard
 go 1.20
 
 require (
-	golang.org/x/crypto v0.13.0
-	golang.org/x/net v0.15.0
-	golang.org/x/sys v0.12.0
+	golang.org/x/crypto v0.21.0
+	golang.org/x/net v0.21.0
+	golang.org/x/sys v0.18.0
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2
 	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
-golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
-golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
-golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
-golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
+golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 h1:vVKdlvoWBphwdxWKrFZEuM0kGgGLxUOYcY4U/2Vjg44=
 golang.org/x/time v0.0.0-20220210224613-90d013bbcef8/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=


### PR DESCRIPTION
x/crypto & x/net old versions contains some CVEs, hence it would be great to bump to newer versions
result of make test:
go test ./...
?       golang.zx2c4.com/wireguard/conn/bindtest        [no test files]
?       golang.zx2c4.com/wireguard/ipc  [no test files]
?       golang.zx2c4.com/wireguard/rwcancel     [no test files]
?       golang.zx2c4.com/wireguard/tun/netstack [no test files]
?       golang.zx2c4.com/wireguard/tun/tuntest  [no test files]
ok      golang.zx2c4.com/wireguard      0.251s
ok      golang.zx2c4.com/wireguard/conn 0.172s
ok      golang.zx2c4.com/wireguard/device       0.904s
ok      golang.zx2c4.com/wireguard/ratelimiter  0.265s
ok      golang.zx2c4.com/wireguard/replay       0.535s
ok      golang.zx2c4.com/wireguard/tai64n       0.399s
ok      golang.zx2c4.com/wireguard/tun  0.786s [no tests to run]