### PR TITLE
[LLT-5312] add logging when read from tun failure happens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+        matrix:
+          include:
+            - arch: x86_64
+              target_os: linux
+            - arch: i686
+              target_os: linux
+            - arch: aarch64
+              target_os: linux
+            - arch: armv7
+              target_os: linux
+            - arch: armv5
+              target_os: linux
+            - arch: x86_64
+              target_os: android
+            - arch: i686
+              target_os: android
+            - arch: aarch64
+              target_os: android
+            - arch: armv7
+              target_os: android
+            - arch: x86_64
+              target_os: windows
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v5
+    - run: export GOOS=${{ matrix.target_os }}
+    - run: export GOARCH=${{ matrix.arch }}
+    - run: go build
+    - run: go test ./...

--- a/conn/bind_telio_std.go
+++ b/conn/bind_telio_std.go
@@ -1,0 +1,76 @@
+package conn
+
+import (
+	"errors"
+	"net"
+	"runtime"
+	"syscall"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+func (bind *StdNetBind) OpenOnLocalhost(uport uint16) (recvFns []ReceiveFunc, selectedPort uint16, err error) {
+	return bind.OpenOnAddr(net.IPv4(127, 0, 0, 1), net.IPv6loopback, uport)
+}
+
+func (s *StdNetBind) OpenOnAddr(ipv4addr net.IP, ipv6addr net.IP, uport uint16) ([]ReceiveFunc, uint16, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var err error
+	var tries int
+
+	if s.ipv4 != nil || s.ipv6 != nil {
+		return nil, 0, ErrBindAlreadyOpen
+	}
+
+	// Attempt to open ipv4 and ipv6 listeners on the same port.
+	// If uport is 0, we can retry on failure.
+again:
+	port := int(uport)
+	var v4conn, v6conn *net.UDPConn
+	var v4pc *ipv4.PacketConn
+	var v6pc *ipv6.PacketConn
+
+	v4conn, port, err = listenNet("udp4", ipv4addr, port)
+	if err != nil && !errors.Is(err, syscall.EAFNOSUPPORT) {
+		return nil, 0, err
+	}
+
+	// Listen on the same port as we're using for ipv4.
+	v6conn, port, err = listenNet("udp6", ipv6addr, port)
+	if uport == 0 && errors.Is(err, syscall.EADDRINUSE) && tries < 100 {
+		v4conn.Close()
+		tries++
+		goto again
+	}
+	if err != nil && !errors.Is(err, syscall.EAFNOSUPPORT) {
+		v4conn.Close()
+		return nil, 0, err
+	}
+	var fns []ReceiveFunc
+	if v4conn != nil {
+		s.ipv4TxOffload, s.ipv4RxOffload = supportsUDPOffload(v4conn)
+		if runtime.GOOS == "linux" || runtime.GOOS == "android" {
+			v4pc = ipv4.NewPacketConn(v4conn)
+			s.ipv4PC = v4pc
+		}
+		fns = append(fns, s.makeReceiveIPv4(v4pc, v4conn, s.ipv4RxOffload))
+		s.ipv4 = v4conn
+	}
+	if v6conn != nil {
+		s.ipv6TxOffload, s.ipv6RxOffload = supportsUDPOffload(v6conn)
+		if runtime.GOOS == "linux" || runtime.GOOS == "android" {
+			v6pc = ipv6.NewPacketConn(v6conn)
+			s.ipv6PC = v6pc
+		}
+		fns = append(fns, s.makeReceiveIPv6(v6pc, v6conn, s.ipv6RxOffload))
+		s.ipv6 = v6conn
+	}
+	if len(fns) == 0 {
+		return nil, 0, syscall.EAFNOSUPPORT
+	}
+
+	return fns, uint16(port), nil
+}

--- a/conn/bind_telio_windows.go
+++ b/conn/bind_telio_windows.go
@@ -1,0 +1,44 @@
+package conn
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func (bind *WinRingBind) OpenOnLocalhost(port uint16) ([]ReceiveFunc, uint16, error) {
+	return bind.OpenOnAddr([4]byte{127, 0, 0, 1}, [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, port)
+}
+
+func (bind *WinRingBind) OpenOnAddr(ipv4addr [4]byte, ipv6addr [16]byte, port uint16) (recvFns []ReceiveFunc, selectedPort uint16, err error) {
+	bind.mu.Lock()
+	defer bind.mu.Unlock()
+	defer func() {
+		if err != nil {
+			bind.closeAndZero()
+		}
+	}()
+	if bind.isOpen.Load() != 0 {
+		return nil, 0, ErrBindAlreadyOpen
+	}
+	var sa windows.Sockaddr
+	sa, err = bind.v4.Open(windows.AF_INET, &windows.SockaddrInet4{Addr: ipv4addr, Port: int(port)})
+	if err != nil {
+		return nil, 0, err
+	}
+	sa, err = bind.v6.Open(windows.AF_INET6, &windows.SockaddrInet6{Addr: ipv6addr, Port: sa.(*windows.SockaddrInet4).Port})
+	if err != nil {
+		return nil, 0, err
+	}
+	selectedPort = uint16(sa.(*windows.SockaddrInet6).Port)
+	for i := 0; i < packetsPerRing; i++ {
+		err = bind.v4.InsertReceiveRequest()
+		if err != nil {
+			return nil, 0, err
+		}
+		err = bind.v6.InsertReceiveRequest()
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	bind.isOpen.Store(1)
+	return []ReceiveFunc{bind.receiveIPv4, bind.receiveIPv6}, selectedPort, err
+}

--- a/conn/bind_windows.go
+++ b/conn/bind_windows.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/net/ipv6"
 	"golang.org/x/sys/windows"
 
-	"golang.zx2c4.com/wireguard/conn/winrio"
+	"github.com/NordSecurity/wireguard-go/conn/winrio"
 )
 
 const (

--- a/conn/bindtest/bindtest.go
+++ b/conn/bindtest/bindtest.go
@@ -12,7 +12,7 @@ import (
 	"net/netip"
 	"os"
 
-	"golang.zx2c4.com/wireguard/conn"
+	"github.com/NordSecurity/wireguard-go/conn"
 )
 
 type ChannelBind struct {

--- a/device/bind_test.go
+++ b/device/bind_test.go
@@ -8,7 +8,7 @@ package device
 import (
 	"errors"
 
-	"golang.zx2c4.com/wireguard/conn"
+	"github.com/NordSecurity/wireguard-go/conn"
 )
 
 type DummyDatagram struct {

--- a/device/device.go
+++ b/device/device.go
@@ -11,10 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/ratelimiter"
-	"golang.zx2c4.com/wireguard/rwcancel"
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/ratelimiter"
+	"github.com/NordSecurity/wireguard-go/rwcancel"
+	"github.com/NordSecurity/wireguard-go/tun"
 )
 
 type Device struct {

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/conn/bindtest"
-	"golang.zx2c4.com/wireguard/tun"
-	"golang.zx2c4.com/wireguard/tun/tuntest"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/conn/bindtest"
+	"github.com/NordSecurity/wireguard-go/tun"
+	"github.com/NordSecurity/wireguard-go/tun/tuntest"
 )
 
 // uapiCfg returns a string that contains cfg formatted use with IpcSet.

--- a/device/keypair.go
+++ b/device/keypair.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.zx2c4.com/wireguard/replay"
+	"github.com/NordSecurity/wireguard-go/replay"
 )
 
 /* Due to limitations in Go and /x/crypto there is currently

--- a/device/noise-protocol.go
+++ b/device/noise-protocol.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/poly1305"
 
-	"golang.zx2c4.com/wireguard/tai64n"
+	"github.com/NordSecurity/wireguard-go/tai64n"
 )
 
 type handshakeState int

--- a/device/noise_test.go
+++ b/device/noise_test.go
@@ -10,8 +10,8 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/tun/tuntest"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/tun/tuntest"
 )
 
 func TestCurveWrappers(t *testing.T) {

--- a/device/peer.go
+++ b/device/peer.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.zx2c4.com/wireguard/conn"
+	"github.com/NordSecurity/wireguard-go/conn"
 )
 
 type Peer struct {

--- a/device/queueconstants_android.go
+++ b/device/queueconstants_android.go
@@ -5,7 +5,7 @@
 
 package device
 
-import "golang.zx2c4.com/wireguard/conn"
+import "github.com/NordSecurity/wireguard-go/conn"
 
 /* Reduce memory consumption for Android */
 

--- a/device/queueconstants_default.go
+++ b/device/queueconstants_default.go
@@ -7,7 +7,7 @@
 
 package device
 
-import "golang.zx2c4.com/wireguard/conn"
+import "github.com/NordSecurity/wireguard-go/conn"
 
 const (
 	QueueStagedSize            = conn.IdealBatchSize

--- a/device/receive.go
+++ b/device/receive.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NordSecurity/wireguard-go/conn"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"golang.zx2c4.com/wireguard/conn"
 )
 
 type QueueHandshakeElement struct {

--- a/device/send.go
+++ b/device/send.go
@@ -310,9 +310,7 @@ func (device *Device) RoutineReadFromTUN() {
 				continue
 			}
 			if !device.isClosed() {
-				if !errors.Is(readErr, os.ErrClosed) {
-					device.log.Errorf("Failed to read packet from TUN device: %v", readErr)
-				}
+				device.log.Errorf("Failed to read packet from TUN device: %v", readErr)
 				go device.Close()
 			}
 			return

--- a/device/send.go
+++ b/device/send.go
@@ -14,11 +14,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/tun"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/tun"
 )
 
 /* Outbound flow

--- a/device/sticky_default.go
+++ b/device/sticky_default.go
@@ -3,8 +3,8 @@
 package device
 
 import (
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/rwcancel"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/rwcancel"
 )
 
 func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, error) {

--- a/device/sticky_linux.go
+++ b/device/sticky_linux.go
@@ -20,8 +20,8 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/rwcancel"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/rwcancel"
 )
 
 func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, error) {

--- a/device/tun.go
+++ b/device/tun.go
@@ -8,7 +8,7 @@ package device
 import (
 	"fmt"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/NordSecurity/wireguard-go/tun"
 )
 
 const DefaultMTU = 1420

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -49,6 +49,10 @@ var byteBufferPool = &sync.Pool{
 // IpcGetOperation implements the WireGuard configuration protocol "get" operation.
 // See https://www.wireguard.com/xplatform/#configuration-protocol for details.
 func (device *Device) IpcGetOperation(w io.Writer) error {
+	if device.isClosed() {
+		return ipcErrorf(ipc.IpcErrorInvalid, "ipc get operation failed: %w", errors.New("device closed"))
+	}
+
 	device.ipcMutex.RLock()
 	defer device.ipcMutex.RUnlock()
 

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.zx2c4.com/wireguard/ipc"
+	"github.com/NordSecurity/wireguard-go/ipc"
 )
 
 type IPCError struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module golang.zx2c4.com/wireguard
+module github.com/NordSecurity/wireguard-go
 
 go 1.20
 

--- a/ipc/namedpipe/namedpipe_test.go
+++ b/ipc/namedpipe/namedpipe_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NordSecurity/wireguard-go/ipc/namedpipe"
 	"golang.org/x/sys/windows"
-	"golang.zx2c4.com/wireguard/ipc/namedpipe"
 )
 
 func randomPipePath() string {

--- a/ipc/uapi_linux.go
+++ b/ipc/uapi_linux.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/NordSecurity/wireguard-go/rwcancel"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/rwcancel"
 )
 
 type UAPIListener struct {

--- a/ipc/uapi_windows.go
+++ b/ipc/uapi_windows.go
@@ -8,8 +8,8 @@ package ipc
 import (
 	"net"
 
+	"github.com/NordSecurity/wireguard-go/ipc/namedpipe"
 	"golang.org/x/sys/windows"
-	"golang.zx2c4.com/wireguard/ipc/namedpipe"
 )
 
 // TODO: replace these with actual standard windows error numbers from the win package

--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/device"
+	"github.com/NordSecurity/wireguard-go/ipc"
+	"github.com/NordSecurity/wireguard-go/tun"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/ipc"
-	"golang.zx2c4.com/wireguard/tun"
 )
 
 const (

--- a/main_windows.go
+++ b/main_windows.go
@@ -12,11 +12,11 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/ipc"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/device"
+	"github.com/NordSecurity/wireguard-go/ipc"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/NordSecurity/wireguard-go/tun"
 )
 
 const (

--- a/tun/netstack/examples/http_client.go
+++ b/tun/netstack/examples/http_client.go
@@ -13,9 +13,9 @@ import (
 	"net/http"
 	"net/netip"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/device"
+	"github.com/NordSecurity/wireguard-go/tun/netstack"
 )
 
 func main() {

--- a/tun/netstack/examples/http_server.go
+++ b/tun/netstack/examples/http_server.go
@@ -14,9 +14,9 @@ import (
 	"net/http"
 	"net/netip"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/device"
+	"github.com/NordSecurity/wireguard-go/tun/netstack"
 )
 
 func main() {

--- a/tun/netstack/examples/ping_client.go
+++ b/tun/netstack/examples/ping_client.go
@@ -17,9 +17,9 @@ import (
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/device"
-	"golang.zx2c4.com/wireguard/tun/netstack"
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/device"
+	"github.com/NordSecurity/wireguard-go/tun/netstack"
 )
 
 func main() {

--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/NordSecurity/wireguard-go/tun"
 
 	"golang.org/x/net/dns/dnsmessage"
 	"gvisor.dev/gvisor/pkg/buffer"

--- a/tun/offload_linux.go
+++ b/tun/offload_linux.go
@@ -12,8 +12,8 @@ import (
 	"io"
 	"unsafe"
 
+	"github.com/NordSecurity/wireguard-go/conn"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
 )
 
 const tcpFlagsOffset = 13

--- a/tun/offload_linux_test.go
+++ b/tun/offload_linux_test.go
@@ -9,8 +9,8 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/NordSecurity/wireguard-go/conn"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 )

--- a/tun/tun_linux.go
+++ b/tun/tun_linux.go
@@ -17,9 +17,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/NordSecurity/wireguard-go/conn"
+	"github.com/NordSecurity/wireguard-go/rwcancel"
 	"golang.org/x/sys/unix"
-	"golang.zx2c4.com/wireguard/conn"
-	"golang.zx2c4.com/wireguard/rwcancel"
 )
 
 const (

--- a/tun/tuntest/tuntest.go
+++ b/tun/tuntest/tuntest.go
@@ -11,7 +11,7 @@ import (
 	"net/netip"
 	"os"
 
-	"golang.zx2c4.com/wireguard/tun"
+	"github.com/NordSecurity/wireguard-go/tun"
 )
 
 func Ping(dst, src netip.Addr) []byte {


### PR DESCRIPTION
During nightly tests on job 13830453 windows has failed to create wintun/wg-go adapter. And the test failed. After some investigation it seems like the tunnel is being destructed from within itself.

The only feasible place where this could happen seems to be here: https://github.com/NordSecurity/wireguard-go/blob/v0.0.2/device/send.go#L316, which is triggered by receiving error while reading from tunnel. In order to guide the investigation further, it would be nice to figure our exactly which error occurs, and thus this PR adds some more detailed logs.