### PR TITLE
global: linter and deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ install: wireguard-go
 test:
 	go test ./...
 
+benchmark:
+	go test -bench=. ./...
+
 clean:
 	rm -f wireguard-go
 

--- a/conn/errors_default.go
+++ b/conn/errors_default.go
@@ -7,6 +7,6 @@
 
 package conn
 
-func errShouldDisableUDPGSO(err error) bool {
+func errShouldDisableUDPGSO(_ error) bool {
 	return false
 }

--- a/conn/features_default.go
+++ b/conn/features_default.go
@@ -10,6 +10,6 @@ package conn
 
 import "net"
 
-func supportsUDPOffload(conn *net.UDPConn) (txOffload, rxOffload bool) {
+func supportsUDPOffload(_ *net.UDPConn) (txOffload, rxOffload bool) {
 	return
 }

--- a/device/allowedips_rand_test.go
+++ b/device/allowedips_rand_test.go
@@ -83,7 +83,7 @@ func TestTrieRandom(t *testing.T) {
 	var peers []*Peer
 	var allowedIPs AllowedIPs
 
-	rand.Seed(1)
+	rng := rand.New(rand.NewSource(1))
 
 	for n := 0; n < NumberOfPeers; n++ {
 		peers = append(peers, &Peer{})
@@ -91,14 +91,14 @@ func TestTrieRandom(t *testing.T) {
 
 	for n := 0; n < NumberOfAddresses; n++ {
 		var addr4 [4]byte
-		rand.Read(addr4[:])
+		rng.Read(addr4[:])
 		cidr := uint8(rand.Intn(32) + 1)
 		index := rand.Intn(NumberOfPeers)
 		allowedIPs.Insert(netip.PrefixFrom(netip.AddrFrom4(addr4), int(cidr)), peers[index])
 		slow4 = slow4.Insert(addr4[:], cidr, peers[index])
 
 		var addr6 [16]byte
-		rand.Read(addr6[:])
+		rng.Read(addr6[:])
 		cidr = uint8(rand.Intn(128) + 1)
 		index = rand.Intn(NumberOfPeers)
 		allowedIPs.Insert(netip.PrefixFrom(netip.AddrFrom16(addr6), int(cidr)), peers[index])
@@ -109,7 +109,7 @@ func TestTrieRandom(t *testing.T) {
 	for p = 0; ; p++ {
 		for n := 0; n < NumberOfTests; n++ {
 			var addr4 [4]byte
-			rand.Read(addr4[:])
+			rng.Read(addr4[:])
 			peer1 := slow4.Lookup(addr4[:])
 			peer2 := allowedIPs.Lookup(addr4[:])
 			if peer1 != peer2 {
@@ -117,7 +117,7 @@ func TestTrieRandom(t *testing.T) {
 			}
 
 			var addr6 [16]byte
-			rand.Read(addr6[:])
+			rng.Read(addr6[:])
 			peer1 = slow6.Lookup(addr6[:])
 			peer2 = allowedIPs.Lookup(addr6[:])
 			if peer1 != peer2 {

--- a/device/allowedips_test.go
+++ b/device/allowedips_test.go
@@ -39,12 +39,12 @@ func TestCommonBits(t *testing.T) {
 	}
 }
 
-func benchmarkTrie(peerNumber, addressNumber, addressLength int, b *testing.B) {
+func benchmarkTrie(peerNumber, addressNumber, _ int, b *testing.B) {
 	var trie *trieEntry
 	var peers []*Peer
 	root := parentIndirection{&trie, 2}
 
-	rand.Seed(1)
+	rng := rand.New(rand.NewSource(1))
 
 	const AddressLength = 4
 
@@ -54,15 +54,15 @@ func benchmarkTrie(peerNumber, addressNumber, addressLength int, b *testing.B) {
 
 	for n := 0; n < addressNumber; n++ {
 		var addr [AddressLength]byte
-		rand.Read(addr[:])
-		cidr := uint8(rand.Uint32() % (AddressLength * 8))
-		index := rand.Int() % peerNumber
+		rng.Read(addr[:])
+		cidr := uint8(rng.Uint32() % (AddressLength * 8))
+		index := rng.Int() % peerNumber
 		root.insert(addr[:], cidr, peers[index])
 	}
 
 	for n := 0; n < b.N; n++ {
 		var addr [AddressLength]byte
-		rand.Read(addr[:])
+		rng.Read(addr[:])
 		trie.lookup(addr[:])
 	}
 }

--- a/device/sticky_default.go
+++ b/device/sticky_default.go
@@ -7,6 +7,6 @@ import (
 	"golang.zx2c4.com/wireguard/rwcancel"
 )
 
-func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, error) {
+func (device *Device) startRouteListener(_ conn.Bind) (*rwcancel.RWCancel, error) {
 	return nil, nil
 }

--- a/device/sticky_linux.go
+++ b/device/sticky_linux.go
@@ -9,7 +9,7 @@
  *
  * Currently there is no way to achieve this within the net package:
  * See e.g. https://github.com/golang/go/issues/17930
- * So this code is remains platform dependent.
+ * So this code remains platform dependent.
  */
 
 package device
@@ -47,7 +47,7 @@ func (device *Device) startRouteListener(bind conn.Bind) (*rwcancel.RWCancel, er
 	return netlinkCancel, nil
 }
 
-func (device *Device) routineRouteListener(bind conn.Bind, netlinkSock int, netlinkCancel *rwcancel.RWCancel) {
+func (device *Device) routineRouteListener(_ conn.Bind, netlinkSock int, netlinkCancel *rwcancel.RWCancel) {
 	type peerEndpointPtr struct {
 		peer     *Peer
 		endpoint *conn.Endpoint


### PR DESCRIPTION
# Context

This is a non-mission critical PR that addresses linter issues, replaces a deprecated call, and adds a `make` task.

The impetus for it is that I recently got back into golang, and have been studying various codebases to further my understanding. Moreover, I have been using `wg` for some time, so as a token of gratitude for the hard work of Jason et al, I also hope to pay it forward by offering a small contribution.

# Changes

- resolves 25 out of the existing 26 linter warnings on `master`; the final change could potentially affect behavior so I left it alone for now
- replaces a deprecated call to `rand.Seed`
- adds a `benchmark` task to Makefile