### PR TITLE
device: reduce RoutineHandshake allocations

### DIFF
--- a/device/noise-protocol_test.go
+++ b/device/noise-protocol_test.go
@@ -1,0 +1,33 @@
+package device
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+var msgSink MessageInitiation
+
+func BenchmarkMessageInitiationUnmarshal(b *testing.B) {
+	packet := make([]byte, MessageInitiationSize)
+	reader := bytes.NewReader(packet)
+	err := binary.Read(reader, binary.LittleEndian, &msgSink)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("binary.Read", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			reader := bytes.NewReader(packet)
+			_ = binary.Read(reader, binary.LittleEndian, &msgSink)
+		}
+	})
+
+	b.Run("unmarshal", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			_ = msgSink.unmarshal(packet)
+		}
+	})
+}

--- a/device/receive.go
+++ b/device/receive.go
@@ -6,7 +6,6 @@
 package device
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"net"
@@ -287,8 +286,7 @@ func (device *Device) RoutineHandshake(id int) {
 			// unmarshal packet
 
 			var reply MessageCookieReply
-			reader := bytes.NewReader(elem.packet)
-			err := binary.Read(reader, binary.LittleEndian, &reply)
+			err := reply.unmarshal(elem.packet)
 			if err != nil {
 				device.log.Verbosef("Failed to decode cookie reply")
 				goto skip
@@ -353,8 +351,7 @@ func (device *Device) RoutineHandshake(id int) {
 			// unmarshal
 
 			var msg MessageInitiation
-			reader := bytes.NewReader(elem.packet)
-			err := binary.Read(reader, binary.LittleEndian, &msg)
+			err := msg.unmarshal(elem.packet)
 			if err != nil {
 				device.log.Errorf("Failed to decode initiation message")
 				goto skip
@@ -386,8 +383,7 @@ func (device *Device) RoutineHandshake(id int) {
 			// unmarshal
 
 			var msg MessageResponse
-			reader := bytes.NewReader(elem.packet)
-			err := binary.Read(reader, binary.LittleEndian, &msg)
+			err := msg.unmarshal(elem.packet)
 			if err != nil {
 				device.log.Errorf("Failed to decode response message")
 				goto skip


### PR DESCRIPTION
Reduce allocations by eliminating byte reader, hand-rolled decoding and reusing message structs.