### PR TITLE
End-application improvements for the tun library use

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -446,6 +446,8 @@ func (t *fakeTUNDeviceSized) Name() (string, error)                        { ret
 func (t *fakeTUNDeviceSized) Events() <-chan tun.Event                     { return nil }
 func (t *fakeTUNDeviceSized) Close() error                                 { return nil }
 func (t *fakeTUNDeviceSized) BatchSize() int                               { return t.size }
+func (t *fakeTUNDeviceSized) MinOffset() int                               { return 0 }
+func (t *fakeTUNDeviceSized) SetCarrier(bool) error                        { return nil }
 
 func TestBatchSize(t *testing.T) {
 	d := Device{}

--- a/tun/checksum.go
+++ b/tun/checksum.go
@@ -5,8 +5,34 @@ import (
 	"math/bits"
 )
 
-// TODO: Explore SIMD and/or other assembly optimizations.
-func checksumNoFold(b []byte, initial uint64) uint64 {
+// IP protocol constants
+const (
+	ProtocolICMP4 = 1
+	ProtocolTCP   = 6
+	ProtocolUDP   = 17
+	ProtocolICMP6 = 58
+)
+
+const (
+	IPv4SrcAddrOffset = 12
+	IPv6SrcAddrOffset = 8
+)
+
+var (
+	// PseudoHeaderProtocolTCP TCP protocol field of the TCP pseudoheader
+	PseudoHeaderProtocolTCP = []byte{0, ProtocolTCP}
+	// PseudoHeaderProtocolUDP UDP protocol field of the UDP pseudoheader
+	PseudoHeaderProtocolUDP = []byte{0, ProtocolUDP}
+	// PseudoHeaderProtocolMap provides dispatch for IP protocol to the corresponding protocol pseudo-header field
+	PseudoHeaderProtocolMap = map[uint8][]byte{
+		ProtocolTCP: PseudoHeaderProtocolTCP,
+		ProtocolUDP: PseudoHeaderProtocolUDP,
+	}
+)
+
+// ChecksumNoFold performs intermediate checksum computation per RFC 1071
+func ChecksumNoFold(b []byte, initial uint64) uint64 {
+	// TODO: Explore SIMD and/or other assembly optimizations.
 	tmp := make([]byte, 8)
 	binary.NativeEndian.PutUint64(tmp, initial)
 	ac := binary.BigEndian.Uint64(tmp)
@@ -83,8 +109,9 @@ func checksumNoFold(b []byte, initial uint64) uint64 {
 	return binary.BigEndian.Uint64(tmp)
 }
 
-func checksum(b []byte, initial uint64) uint16 {
-	ac := checksumNoFold(b, initial)
+// Checksum performs final checksum computation per RFC 1071
+func Checksum(b []byte, initial uint64) uint16 {
+	ac := ChecksumNoFold(b, initial)
 	ac = (ac >> 16) + (ac & 0xffff)
 	ac = (ac >> 16) + (ac & 0xffff)
 	ac = (ac >> 16) + (ac & 0xffff)
@@ -92,11 +119,66 @@ func checksum(b []byte, initial uint64) uint16 {
 	return uint16(ac)
 }
 
-func pseudoHeaderChecksumNoFold(protocol uint8, srcAddr, dstAddr []byte, totalLen uint16) uint64 {
-	sum := checksumNoFold(srcAddr, 0)
-	sum = checksumNoFold(dstAddr, sum)
-	sum = checksumNoFold([]byte{0, protocol}, sum)
-	tmp := make([]byte, 2)
-	binary.BigEndian.PutUint16(tmp, totalLen)
-	return checksumNoFold(tmp, sum)
+// PseudoHeaderChecksumNoFold performs intermediate checksum computation for TCP/UDP pseudoheader values
+func PseudoHeaderChecksumNoFold(protocol, srcDstAddr, totalLen []byte) uint64 {
+	sum := ChecksumNoFold(srcDstAddr, 0)
+	sum = ChecksumNoFold(protocol, sum)
+	return ChecksumNoFold(totalLen, sum)
+}
+
+// ComputeIPChecksum updates IP and TCP/UDP checksums
+func ComputeIPChecksum(pkt []byte) {
+	ComputeIPChecksumBuffer(pkt, false)
+}
+
+// ComputeIPChecksumBuffer updates IP and TCP/UDP checksums using the provided length buffer of size 2
+func ComputeIPChecksumBuffer(pkt []byte, partial bool) {
+	var (
+		lenbuf    [2]byte
+		addrsum   uint64
+		protocol  uint8
+		headerLen int
+		totalLen  uint16
+	)
+
+	if pkt[0]>>4 == 4 {
+		pkt[10], pkt[11] = 0, 0 // clear IP header checksum
+		protocol = pkt[9]
+		ihl := pkt[0] & 0xF
+		headerLen = int(ihl * 4)
+		totalLen = binary.BigEndian.Uint16(pkt[2:])
+		addrsum = ChecksumNoFold(pkt[IPv4SrcAddrOffset:IPv4SrcAddrOffset+8], 0)
+		binary.BigEndian.PutUint16(pkt[10:], ^Checksum(pkt[:IPv4SrcAddrOffset], addrsum))
+	} else {
+		protocol = pkt[6]
+		headerLen = 40
+		totalLen = 40 + binary.BigEndian.Uint16(pkt[4:])
+		addrsum = ChecksumNoFold(pkt[IPv6SrcAddrOffset:IPv6SrcAddrOffset+32], 0)
+	}
+
+	switch protocol {
+	case ProtocolTCP:
+		pkt[headerLen+16], pkt[headerLen+17] = 0, 0
+		binary.BigEndian.PutUint16(lenbuf[:], totalLen-uint16(headerLen))
+		tcpCSum := ChecksumNoFold(PseudoHeaderProtocolTCP, addrsum)
+		tcpCSum = ChecksumNoFold(lenbuf[:], tcpCSum)
+		if partial {
+			binary.BigEndian.PutUint16(pkt[headerLen+16:], Checksum([]byte{}, tcpCSum))
+		} else {
+			binary.BigEndian.PutUint16(pkt[headerLen+16:], ^Checksum(pkt[headerLen:totalLen], tcpCSum))
+		}
+	case ProtocolUDP:
+		pkt[headerLen+6], pkt[headerLen+7] = 0, 0
+		binary.BigEndian.PutUint16(lenbuf[:], totalLen-uint16(headerLen))
+		udpCSum := ChecksumNoFold(PseudoHeaderProtocolUDP, addrsum)
+		udpCSum = ChecksumNoFold(lenbuf[:], udpCSum)
+		if partial {
+			binary.BigEndian.PutUint16(pkt[headerLen+6:], Checksum([]byte{}, udpCSum))
+		} else {
+			binary.BigEndian.PutUint16(pkt[headerLen+6:], ^Checksum(pkt[headerLen:totalLen], udpCSum))
+		}
+	case ProtocolICMP4, ProtocolICMP6:
+		pkt[headerLen+2], pkt[headerLen+3] = 0, 0
+		binary.BigEndian.PutUint16(pkt[headerLen+2:], ^Checksum(pkt[headerLen:totalLen], 0))
+	}
 }

--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -191,6 +191,14 @@ func (tun *netTun) BatchSize() int {
 	return 1
 }
 
+func (tun *netTun) MinOffset() int {
+	return 0
+}
+
+func (tun *netTun) SetCarrier(bool) error {
+	return nil
+}
+
 func convertToFullAddr(endpoint netip.AddrPort) (tcpip.FullAddress, tcpip.NetworkProtocolNumber) {
 	var protoNumber tcpip.NetworkProtocolNumber
 	if endpoint.Addr().Is4() {

--- a/tun/tun.go
+++ b/tun/tun.go
@@ -26,12 +26,14 @@ type Device interface {
 	// packet lengths within the sizes slice. len(sizes) must be >= len(bufs).
 	// A nonzero offset can be used to instruct the Device on where to begin
 	// reading into each element of the bufs slice.
+	// A value of offset must be equal or greater than indicated by MinOffset()
 	Read(bufs [][]byte, sizes []int, offset int) (n int, err error)
 
 	// Write one or more packets to the device (without any additional headers).
 	// On a successful write it returns the number of packets written. A nonzero
 	// offset can be used to instruct the Device on where to begin writing from
 	// each packet contained within the bufs slice.
+	// A value of offset must be equal or greater than indicated by MinOffset()
 	Write(bufs [][]byte, offset int) (int, error)
 
 	// MTU returns the MTU of the Device.
@@ -43,6 +45,9 @@ type Device interface {
 	// Events returns a channel of type Event, which is fed Device events.
 	Events() <-chan Event
 
+	// SetCarrier sets carrier indication
+	SetCarrier(present bool) error
+
 	// Close stops the Device and closes the Event channel.
 	Close() error
 
@@ -50,4 +55,7 @@ type Device interface {
 	// written in a single read/write call. BatchSize must not change over the
 	// lifetime of a Device.
 	BatchSize() int
+
+	// MinOffset indicates minimum offset value buffers must use
+	MinOffset() int
 }

--- a/tun/tuntest/tuntest.go
+++ b/tun/tuntest/tuntest.go
@@ -153,3 +153,5 @@ func (t *chTun) Close() error {
 	t.Write(nil, -1)
 	return nil
 }
+func (t *chTun) MinOffset() int        { return 0 }
+func (t *chTun) SetCarrier(bool) error { return nil }


### PR DESCRIPTION
Adds some minor quality of life improvements for other applications relying on the widely ported tun implementation, namely:

- Adds support for functional options, to provide new options and extend them in the future without affecting the interface contract, as a new variadic argument on `CreateTUN` should be backwards compatible for current users. 
- Adds option to disable offloads when those are available. 
- Adds support for enforced checksum calculation via functional option, mostly useful to linux with checksum offloading, to avoid double checksum calculation (first in application, then in tun library) when packet manipulation is frequent. Also exposes checksum calculation function to applications and merges src/dst fields to involve larger loop unrolls.
- Adds support for carrier indication, currently only on linux, via `SetCarrier(bool) error` on `tun.Device` and a functional option to provide initial state.
- Exposes `MinOffset() int` on `tun.Device` to indicate required platform-specific offset in buffers to application. 

New methods in `tun.Device` may be breaking to current third-party implementors of this interface, if there are any.